### PR TITLE
Ivan/use cache

### DIFF
--- a/lib/Data/Hash/DotNotation.pm
+++ b/lib/Data/Hash/DotNotation.pm
@@ -46,7 +46,8 @@ has '_cache' => (
 sub get {
     my $self = shift;
     my $name = shift or croak "No name given";
-    return $self->_get($name);
+
+    return $self->_cache->{$name};
 }
 
 sub set {
@@ -84,14 +85,6 @@ sub _populate_cache {
         _update_cache_recursive($k, $v, undef, $cache);
     }
     $self->_cache($cache);
-}
-
-sub _get {
-    my $self = shift;
-    my $name = shift;
-    my $cache = $self->_cache;
-
-    return $cache->{$name};
 }
 
 sub _set {

--- a/lib/Data/Hash/DotNotation.pm
+++ b/lib/Data/Hash/DotNotation.pm
@@ -1,7 +1,7 @@
 package Data::Hash::DotNotation;
 use strict; use warnings;
 
-our $VERSION = '1.01';
+our $VERSION = '1.02';
 
 use Moose;
 use Carp;

--- a/t/02-synopsis.t
+++ b/t/02-synopsis.t
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+use strict; use warnings;
+
+use lib 'lib';
+use Data::Hash::DotNotation;
+use Test::More;
+use Test::Exception;
+
+my $dn = Data::Hash::DotNotation->new;
+
+$dn->data({
+        name => 'Gurgeh',
+        planet  => 'earth',
+        score   => {
+            contact => 10,
+            scrabble => 20,
+        },
+    });
+
+is $dn->get('score.contact'), 10;
+
+$dn->data({
+        k1 => 'v1',
+        h1 => {
+          k2 => 23,
+        }
+    });
+
+is $dn->get('score.contact'), undef, "old cache has been invalidated";
+is $dn->get('k1'), 'v1';
+is $dn->get('h1.k2'), 23;
+
+done_testing;


### PR DESCRIPTION
I propose populate the `_cache` on data load / set key with already valid "dot-keys", like `version.info` etc. 

Then `get` method would be rather simple and faster : no need to traverse by several caches, create strings via split etc. If you prefer math, it's O(1) instead O(N) access time, where N - is key complexity (aka number of dots + 1).
